### PR TITLE
fix: replace hardcoded paths with relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ git clone https://github.com/wrsmith108/claude-skill-security-auditor.git ~/.cla
 ### Standalone Usage
 
 ```bash
-npx tsx ~/.claude/skills/security-auditor/scripts/index.ts [options]
+npx tsx scripts/index.ts [options]
 ```
 
 ## Trigger Phrases
@@ -110,7 +110,7 @@ The skill generates a markdown report with:
 
 ```yaml
 - name: Security Audit
-  run: npx tsx ~/.claude/skills/security-auditor/scripts/index.ts --fail-on high
+  run: npx tsx scripts/index.ts --fail-on high
 ```
 
 ## Requirements

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -48,7 +48,7 @@ function printHelp(): void {
 Security Auditor - Run structured security audits with actionable remediation plans
 
 Usage:
-  npx tsx ~/.claude/skills/security-auditor/scripts/index.ts [options]
+  npx tsx scripts/index.ts [options]
 
 Options:
   --json              Output in JSON format
@@ -59,16 +59,16 @@ Options:
 
 Examples:
   # Basic audit with markdown report
-  npx tsx ~/.claude/skills/security-auditor/scripts/index.ts
+  npx tsx scripts/index.ts
 
   # JSON output for CI integration
-  npx tsx ~/.claude/skills/security-auditor/scripts/index.ts --json
+  npx tsx scripts/index.ts --json
 
   # Fail CI on high or critical vulnerabilities
-  npx tsx ~/.claude/skills/security-auditor/scripts/index.ts --fail-on high
+  npx tsx scripts/index.ts --fail-on high
 
   # Audit a specific project
-  npx tsx ~/.claude/skills/security-auditor/scripts/index.ts --cwd /path/to/project
+  npx tsx scripts/index.ts --cwd /path/to/project
 
 Exit Codes:
   0 - Success (no vulnerabilities above threshold)


### PR DESCRIPTION
## Summary
- Replace hardcoded ~/.claude/skills/ script invocation paths with relative paths
- Supports project-local skill installations in .claude/skills/
- Install/clone destination paths preserved as-is

## Linear Issue
SMI-2430

Generated with [claude-flow](https://github.com/ruvnet/claude-flow)