### PR TITLE
chore(release): bump to 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ The skill generates a markdown report with:
 - Valid `package.json` in target directory
 - Optional: `package-lock.json` for accurate audit
 
+## Changelog
+
+### 1.0.1 (2026-02-10)
+
+- **Fixed**: Replaced hardcoded `~/.claude/skills/` paths with relative paths for portability across different install locations
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrsmith108/claude-skill-security-auditor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Claude Code skill for running structured security audits with actionable remediation plans",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
## Summary
- Bump version from 1.0.0 to 1.0.1
- Add changelog section to README documenting the path portability fix

Co-Authored-By: claude-flow <ruv@ruv.net>